### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ composer require archon/dataframe
 
 ## Data Format Examples
 
+### Import required library
+
+`use Archon\DataFrame;`
+
 ### Instantiating from an array:
 
 ```php


### PR DESCRIPTION
Clarify the required `use Archon\DataFrame;` sentence for novices like me. God knows I had took nearly 2 hours to found out why it cannot be used. All the online tutorials told you to `require __DIR__ . '/vendor/autoload.php';` but they never told you how to use them. Hope there'll be no poor guy like me to be bothered by such a simple problem.